### PR TITLE
Playlist page revalidation & tracks staging before actual removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "prod": "next build && next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -10,9 +10,16 @@ interface TrackProps {
   track: TrackType;
   isActive: boolean;
   onClick: () => void;
+  onRemove?: (trackId: string) => void;
 }
 
-const Track: React.FC<TrackProps> = ({ index, track, isActive, onClick }) => {
+const Track: React.FC<TrackProps> = ({
+  index,
+  track,
+  isActive,
+  onClick,
+  onRemove,
+}) => {
   return (
     <div className="flex justify-between items-center mx-4">
       <div className="flex py-2 space-x-2">
@@ -30,13 +37,13 @@ const Track: React.FC<TrackProps> = ({ index, track, isActive, onClick }) => {
         </p>
       </div>
 
-      <Dropdown horizontal="left" vertical="middle">
+      <Dropdown horizontal="left" vertical="middle" className="pr-4">
         <Dropdown.Toggle size="xs">
           <EllipsisIcon />
         </Dropdown.Toggle>
 
         <Dropdown.Menu className="w-52 m-1">
-          <TrackDropdown index={index} track={track} />
+          <TrackDropdown index={index} track={track} onRemove={onRemove} />
         </Dropdown.Menu>
       </Dropdown>
     </div>

--- a/src/components/TrackDropdown.tsx
+++ b/src/components/TrackDropdown.tsx
@@ -6,17 +6,22 @@ import usePlayerStore from "@/store";
 
 import useLibrary from "@/hooks/react-query/useLibrary";
 import useAddTrack from "@/hooks/react-query/useAddTrack";
-import useRemoveTrack from "@/hooks/react-query/useRemoveTrack";
+import useRemoveTrack from "@/hooks/react-query/useRemoveTracks";
 
 import { Alert, Button, Checkbox } from "react-daisyui";
 
 interface TrackDropdownProps {
   index: number;
   track: TrackType;
+  onRemove?: (trackId: string) => void;
 }
 
-const TrackDropdown: React.FC<TrackDropdownProps> = ({ index, track }) => {
-  const { pathname } = useRouter();
+const TrackDropdown: React.FC<TrackDropdownProps> = ({
+  index,
+  track,
+  onRemove,
+}) => {
+  const { pathname, query } = useRouter();
 
   const { addToQueue, removeFromQueue } = usePlayerStore((state) => state);
 
@@ -29,7 +34,11 @@ const TrackDropdown: React.FC<TrackDropdownProps> = ({ index, track }) => {
   };
 
   const removeFromPlaylist = (playlistId: string) => {
-    mutateRemove({ playlistId, trackId: track.id });
+    if (onRemove && query.playlistId === playlistId) {
+      onRemove(track.id);
+    } else {
+      mutateRemove({ playlistId, tracks: [track.id] });
+    }
   };
 
   return (

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,7 +1,14 @@
-import { RiArrowDropRightLine, RiCheckLine, RiMoreFill } from "react-icons/ri";
+import {
+  RiArrowDropRightLine,
+  RiArrowGoBackFill,
+  RiCheckLine,
+  RiMoreFill,
+} from "react-icons/ri";
 
 export const ChevronRightIcon = () => <RiArrowDropRightLine />;
 
 export const CheckboxIcon = () => <RiCheckLine />;
 
 export const EllipsisIcon = () => <RiMoreFill />;
+
+export const GoBackIcon = () => <RiArrowGoBackFill />;

--- a/src/hooks/react-query/useRemoveTracks.ts
+++ b/src/hooks/react-query/useRemoveTracks.ts
@@ -1,14 +1,14 @@
 import { LibraryApi } from "@/pages/api/library";
 
-import { removeTrackFromPlaylist } from "@/lib/fetchers";
+import { removeTracksFromPlaylist } from "@/lib/fetchers";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-const useRemoveTrack = () => {
+const useRemoveTracks = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: removeTrackFromPlaylist,
-    onMutate: async ({ playlistId, trackId }) => {
+    mutationFn: removeTracksFromPlaylist,
+    onMutate: async ({ playlistId, tracks }) => {
       await queryClient.cancelQueries({ queryKey: ["library"] });
 
       const previousLibrary = queryClient.getQueryData<LibraryApi>(["library"]);
@@ -20,7 +20,9 @@ const useRemoveTrack = () => {
             .pop();
 
           if (playlist) {
-            playlist.tracks = playlist.tracks.filter((id) => id !== trackId);
+            playlist.tracks = playlist.tracks.filter(
+              (id) => !new Set(tracks).has(id)
+            );
             return { ...old };
           }
         }
@@ -42,4 +44,4 @@ const useRemoveTrack = () => {
   });
 };
 
-export default useRemoveTrack;
+export default useRemoveTracks;

--- a/src/hooks/useUnmount.ts
+++ b/src/hooks/useUnmount.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from "react";
+
+function useLatest<T>(value: T) {
+  const ref = useRef(value);
+  ref.current = value;
+
+  return ref;
+}
+
+const useUnmount = (fn: () => void) => {
+  if (process.env.NODE_ENV === "development") {
+    if (typeof fn !== "function") {
+      console.error(
+        `useUnmount expected parameter is a function, got ${typeof fn}`
+      );
+    }
+  }
+
+  const fnRef = useLatest(fn);
+
+  useEffect(
+    () => () => {
+      fnRef.current();
+    },
+    []
+  );
+};
+
+export default useUnmount;

--- a/src/lib/fetchers.ts
+++ b/src/lib/fetchers.ts
@@ -23,9 +23,9 @@ export const addTrackToPlaylist = async (args: {
   return (await axios.post(`/api/track/add`, args)).data;
 };
 
-export const removeTrackFromPlaylist = async (args: {
+export const removeTracksFromPlaylist = async (args: {
   playlistId: string;
-  trackId: string;
+  tracks: string[];
 }) => {
   return (await axios.post(`/api/track/remove`, args)).data;
 };

--- a/src/pages/api/track/add.ts
+++ b/src/pages/api/track/add.ts
@@ -46,6 +46,8 @@ export default async function handler(req: Request, res: NextApiResponse) {
       },
     });
 
+    await res.revalidate(`/playlist/${playlistId}`);
+
     return res.status(200).json({ status: true, trackId, playlistId });
   } catch (error) {
     return res.status(500);


### PR DESCRIPTION
- [x] If a user removes tracks from the current opened playlist, those tracks marks as staged to remove (with appropriate styles) and actually being removed when the page unmounts. Every marked track can be unmarked – a special button has been added.
- [x] If a user adds or removes track from any other playlist, the page of that playlist being revalidated on every successful add/remove request, thus the page rebuilds and contain the actual data.

_____

- [x] https://github.com/sdffn4/music-app/issues/12